### PR TITLE
Buffered reads and writes where possible

### DIFF
--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -56,18 +56,19 @@ func NewIndexWriter(writer io.WriteCloser) *IndexWriter {
 }
 
 func (w *IndexWriter) WriteFromOffsets(offsets sstable.KeyMap) error {
+	bw := bufio.NewWriter(w.writer)
 	for key, offset := range offsets {
 		record := indexv1.IndexEntry{
 			Key:    key,
 			Offset: offset,
 		}
-		_, err := storage.WriteLengthPrefixedProtobufMessage(w.writer, &record)
+		_, err := storage.WriteLengthPrefixedProtobufMessage(bw, &record)
 		if err != nil {
 			return err
 		}
 	}
 
-	return nil
+	return bw.Flush()
 }
 
 func (w *IndexWriter) Close() error {

--- a/internal/journal/reader.go
+++ b/internal/journal/reader.go
@@ -1,6 +1,7 @@
 package journal
 
 import (
+	"bufio"
 	"fmt"
 	"io"
 
@@ -9,11 +10,11 @@ import (
 )
 
 type JournalReader struct {
-	r io.Reader
+	r *bufio.Reader
 }
 
 func NewJournalReader(r io.Reader) *JournalReader {
-	return &JournalReader{r: r}
+	return &JournalReader{r: bufio.NewReader(r)}
 }
 
 func (j *JournalReader) Read(journalEntry protoreflect.ProtoMessage) error {

--- a/internal/sstable/sstable.go
+++ b/internal/sstable/sstable.go
@@ -59,12 +59,12 @@ func (w *SSTableWriter) WrittenOffsets() KeyMap {
 }
 
 type SSTableReader struct {
-	reader io.Reader
+	reader *bufio.Reader
 }
 
 func NewSSTableReader(reader io.Reader) *SSTableReader {
 	return &SSTableReader{
-		reader: reader,
+		reader: bufio.NewReader(reader),
 	}
 }
 


### PR DESCRIPTION
Most of the storage types are small messages so buffering reading and writing should lead to fewer os operations.